### PR TITLE
Support passing an options object or encoding.

### DIFF
--- a/lib/fake-fs.js
+++ b/lib/fake-fs.js
@@ -149,14 +149,16 @@ Fs.prototype.readdirSync = function(dir) {
   return Object.keys(item.children)
 }
 
-Fs.prototype.readFileSync = function(filename, encoding) {
+Fs.prototype.readFileSync = function(filename, options) {
+  var encoding = options && ((typeof options === 'string') ? options : options.encoding)
   var item = this._get(filename)
   if (item.isDirectory()) throw FsError('EISDIR')
   var buf = item.content
   return encoding ? buf.toString(encoding) : buf
 }
 
-Fs.prototype.writeFileSync = function(filename, data, encoding) {
+Fs.prototype.writeFileSync = function(filename, data, options) {
+  var encoding = options && ((typeof options === 'string') ? options : options.encoding)
   var parent = this._get(dirname(filename))
   if (!parent.isDirectory()) throw FsError('ENOTDIR')
   if (!this.existsSync(filename)) {
@@ -165,7 +167,8 @@ Fs.prototype.writeFileSync = function(filename, data, encoding) {
   this.file(filename, data, encoding)
 }
 
-Fs.prototype.appendFileSync = function(filename, data, encoding) {
+Fs.prototype.appendFileSync = function(filename, data, options) {
+  var encoding = options && ((typeof options === 'string') ? options : options.encoding)
   var item = this._itemAt(filename)
   if (item) {
     if (item.isDirectory()) throw FsError('EISDIR')
@@ -241,29 +244,28 @@ Fs.prototype.renameSync = function(oldPath, newPath) {
   }
 })
 
-Fs.prototype.readFile = function(filename, encoding, cb) {
-  if (typeof encoding != 'string') {
-    cb = encoding
-    encoding = undefined
+Fs.prototype.readFile = function(filename, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = undefined
   }
   var res, err
   try {
-    res = this.readFileSync(filename, encoding)
+    res = this.readFileSync(filename, options)
   } catch(e) {
     err = e
   }
   cb && cb(err, res)
 }
 
-Fs.prototype.writeFile = function(filename, data, encoding, cb) {
-  if (typeof encoding == 'function') {
-    cb = encoding
-    encoding = null
+Fs.prototype.writeFile = function(filename, data, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = null
   }
-  encoding = encoding || 'utf8'
   var err
   try {
-    this.writeFileSync(filename, data, encoding)
+    this.writeFileSync(filename, data, options)
   } catch(e) {
     err = e
   }

--- a/test/fake-fs.js
+++ b/test/fake-fs.js
@@ -104,6 +104,12 @@ describe('Fake FS', function() {
       fs.readFileSync('bin2')[0].should.equal(10)
     })
 
+    it('Should support options param in place of encoding', function() {
+      fs.file('hello.txt', 'hello')
+        .readFileSync('hello.txt', { encoding: 'utf8' })
+        .should.equal('hello')
+    })
+
     it('Should support options param', function() {
       fs.file('hello.txt', {
         atime: 10,
@@ -394,6 +400,11 @@ describe('Fake FS', function() {
       cb.result().should.equal('a')
     })
 
+    it('Should respect encoding option', function() {
+      fs.file('file.txt', 'a').readFile('file.txt', { encoding: 'utf8' }, cb)
+      cb.result().should.equal('a')
+    })
+
     it('Should throw ENOENT on non-existent file', function() {
       fs.readFile('foo', cb)
       cb.error('ENOENT')
@@ -414,6 +425,12 @@ describe('Fake FS', function() {
 
     it('Should respect encoding', function() {
       fs.dir('.').writeFile('a', 'TWFu', 'base64', cb)
+      cb.result()
+      fs.readFileSync('a', 'utf8').should.equal('Man')
+    })
+
+    it('Should respect encoding from options object', function() {
+      fs.dir('.').writeFile('a', 'TWFu', { encoding: 'base64'}, cb)
       cb.result()
       fs.readFileSync('a', 'utf8').should.equal('Man')
     })
@@ -445,6 +462,13 @@ describe('Fake FS', function() {
       it('Should append contents to the file', function() {
         fs.file('a', 'hello')
         fs.appendFile('a', 'world', cb)
+        cb.result()
+        fs.readFileSync('a', 'utf8').should.equal('helloworld')
+      })
+
+      it('Should respect the encoding option', function() {
+        fs.file('a', 'hello')
+        fs.appendFile('a', 'world', { encoding: 'utf8' }, cb)
         cb.result()
         fs.readFileSync('a', 'utf8').should.equal('helloworld')
       })


### PR DESCRIPTION
As of node v0.10.0, `readFile`/`writeFile`/etc take either the encoding
string as v0.8.0 did or an object with an encoding key. This updates
the API to allow either argument, as v0.10.0 does.
